### PR TITLE
Add a basic optimized solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 project(Minesweeper)
 
 set(SRCS
+    "src/solvers/basic_optimized.h"
     "src/solvers/brute_force.h"
     "src/solvers/solution_info.h"
 

--- a/src/board_image.cpp
+++ b/src/board_image.cpp
@@ -1,5 +1,7 @@
 #include "board_image.h"
 
+#include "solvers/solution_info.h"
+
 #include <sstream>
 
 BoardImage::BoardImage(const BoardData& data)

--- a/src/board_image.h
+++ b/src/board_image.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include "solvers/solution_info.h"
 #include "types.h"
 #include "util/static_vector.h"
 #include <ostream>
 #include <unordered_map>
 #include <vector>
+
+struct SolutionInfo;
 
 struct CellInfo
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,9 +80,9 @@ int main()
 
     // generateTestSuite();
 
-    run_test_suite(TestSuite::EASY);
-    run_test_suite(TestSuite::MEDIUM);
-    run_test_suite(TestSuite::HARD);
+    run_test_suite(TestSuite::EASY, solvers::brute_force::solve);
+    run_test_suite(TestSuite::MEDIUM, solvers::brute_force::solve);
+    run_test_suite(TestSuite::HARD, solvers::brute_force::solve);
 
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include "board.h"
+#include "solvers/basic_optimized.h"
 #include "solvers/brute_force.h"
 #include "test_suite.h"
 #include "test_suite_gen.h"
@@ -80,9 +81,13 @@ int main()
 
     // generateTestSuite();
 
-    run_test_suite(TestSuite::EASY, solvers::brute_force::solve);
-    run_test_suite(TestSuite::MEDIUM, solvers::brute_force::solve);
-    run_test_suite(TestSuite::HARD, solvers::brute_force::solve);
+    run_test_suite(TestSuite::EASY, solvers::basic_optimized::solve);
+    run_test_suite(TestSuite::MEDIUM, solvers::basic_optimized::solve);
+    run_test_suite(TestSuite::HARD, solvers::basic_optimized::solve);
+
+    // run_test_suite(TestSuite::EASY, solvers::brute_force::solve);
+    // run_test_suite(TestSuite::MEDIUM, solvers::brute_force::solve);
+    // run_test_suite(TestSuite::HARD, solvers::brute_force::solve);
 
     return 0;
 }

--- a/src/solvers/basic_optimized.h
+++ b/src/solvers/basic_optimized.h
@@ -105,23 +105,30 @@ inline std::optional<SolutionInfo> solve(const BoardImage& image)
     uint64_t alwaysClear = (1ull << uncleared.size()) - 1;
     SolutionInfo solution = {};
 
-    for (uint64_t mines = 0; mines < 1ull << uncleared.size(); mines++)
+    for (uint64_t mines = 0; mines < 1ull << uncleared.size();)
     {
+        int jumpBit = 0;
         bool valid = true;
         for (const auto& constraint : constraints)
         {
             if (std::popcount(constraint.mask & mines) != constraint.sum)
             {
                 valid = false;
-                break;
+                jumpBit = std::max(jumpBit, std::countr_zero(constraint.mask));
             }
         }
         if (!valid)
+        {
+            mines &= ~((1ull << jumpBit) - 1);
+            mines += 1ull << jumpBit;
             continue;
+        }
 
         solution.numValidSolutions++;
         alwaysMines &= mines;
         alwaysClear &= ~mines;
+
+        mines++;
     }
 
     while (alwaysMines)

--- a/src/solvers/basic_optimized.h
+++ b/src/solvers/basic_optimized.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include "../board_image.h"
+#include "../util/bitset.h"
+#include "brute_force.h"
+#include "solution_info.h"
+
+#include <bit>
+#include <unordered_map>
+
+namespace solvers::basic_optimized
+{
+
+inline std::optional<SolutionInfo> solve(const BoardImage& image)
+{
+    constexpr uint32_t MAX_UNCLEARED = 35;
+
+    std::unordered_map<Point, bool, PointHash> earlySolves;
+
+    while (true)
+    {
+        bool foundSolve = false;
+        for (const auto& cell : image.numberedCells())
+        {
+            uint32_t knownMines = 0;
+            uint32_t knownClears = 0;
+            for (Point neighbor : cell.unclearedNeighbors)
+            {
+                if (earlySolves.count(neighbor) > 0)
+                {
+                    if (earlySolves.at(neighbor))
+                        knownMines++;
+                    else
+                        knownClears++;
+                }
+            }
+
+            // all cells that are not already known are mines
+            if (cell.adjacentMines == cell.unclearedNeighbors.size() - knownClears)
+            {
+                for (Point neighbor : cell.unclearedNeighbors)
+                {
+                    if (earlySolves.count(neighbor) == 0)
+                    {
+                        foundSolve = true;
+                        earlySolves.insert({neighbor, true});
+                    }
+                }
+            }
+            // all cells that are not already known are clear
+            else if (cell.adjacentMines == knownMines)
+            {
+                for (Point neighbor : cell.unclearedNeighbors)
+                {
+                    if (earlySolves.count(neighbor) == 0)
+                    {
+                        foundSolve = true;
+                        earlySolves.insert({neighbor, false});
+                    }
+                }
+            }
+        }
+
+        if (!foundSolve)
+            break;
+    }
+
+    std::unordered_map<Point, uint32_t, PointHash> unclearedIndices;
+    std::vector<Point> uncleared;
+    std::vector<brute_force::Constraint> constraints;
+
+    for (const auto& cell : image.numberedCells())
+    {
+        brute_force::Constraint constraint = {};
+        uint32_t knownMines = 0;
+        for (auto neighbor : cell.unclearedNeighbors)
+        {
+            if (earlySolves.count(neighbor) > 0)
+            {
+                if (earlySolves.at(neighbor))
+                    knownMines++;
+                continue;
+            }
+            uint32_t idx;
+            if (unclearedIndices.count(neighbor) == 0)
+            {
+                idx = uncleared.size();
+                uncleared.push_back(neighbor);
+                unclearedIndices.insert({neighbor, idx});
+            }
+            else
+            {
+                idx = unclearedIndices.at(neighbor);
+            }
+            constraint.addIndex(idx);
+        }
+        constraint.sum = cell.adjacentMines - knownMines;
+        constraints.push_back(constraint);
+    }
+
+    if (uncleared.size() >= MAX_UNCLEARED)
+        return {};
+
+    uint64_t alwaysMines = (1ull << uncleared.size()) - 1;
+    uint64_t alwaysClear = (1ull << uncleared.size()) - 1;
+    SolutionInfo solution = {};
+
+    for (uint64_t mines = 0; mines < 1ull << uncleared.size(); mines++)
+    {
+        bool valid = true;
+        for (const auto& constraint : constraints)
+        {
+            if (std::popcount(constraint.mask & mines) != constraint.sum)
+            {
+                valid = false;
+                break;
+            }
+        }
+        if (!valid)
+            continue;
+
+        solution.numValidSolutions++;
+        alwaysMines &= mines;
+        alwaysClear &= ~mines;
+    }
+
+    while (alwaysMines)
+    {
+        int mine = poplsb(alwaysMines);
+        solution.mines.push_back(uncleared[mine]);
+    }
+
+    while (alwaysClear)
+    {
+        int clear = poplsb(alwaysClear);
+        solution.clears.push_back(uncleared[clear]);
+    }
+
+    for (auto [location, isMine] : earlySolves)
+    {
+        if (isMine)
+            solution.mines.push_back(location);
+        else
+            solution.clears.push_back(location);
+    }
+
+    return {solution};
+}
+
+}

--- a/src/solvers/brute_force.h
+++ b/src/solvers/brute_force.h
@@ -5,8 +5,6 @@
 #include "solution_info.h"
 
 #include <bit>
-#include <iostream>
-#include <optional>
 #include <unordered_map>
 
 namespace solvers::brute_force
@@ -23,8 +21,10 @@ struct Constraint
     }
 };
 
-inline std::optional<SolutionInfo> solve(const BoardImage& image, uint32_t maxUncleared = 35)
+inline std::optional<SolutionInfo> solve(const BoardImage& image)
 {
+    constexpr uint32_t MAX_UNCLEARED = 35;
+
     std::unordered_map<Point, uint32_t, PointHash> unclearedIndices;
     std::vector<Point> uncleared;
     std::vector<Constraint> constraints;
@@ -51,7 +51,7 @@ inline std::optional<SolutionInfo> solve(const BoardImage& image, uint32_t maxUn
         constraints.push_back(constraint);
     }
 
-    if (uncleared.size() >= maxUncleared)
+    if (uncleared.size() >= MAX_UNCLEARED)
         return {};
 
     uint64_t alwaysMines = (1ull << uncleared.size()) - 1;

--- a/src/solvers/solution_info.h
+++ b/src/solvers/solution_info.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <functional>
+#include <optional>
 #include <vector>
 
+#include "../board_image.h"
 #include "../types.h"
 
 struct SolutionInfo
@@ -30,3 +33,5 @@ struct SolutionInfo
         return false;
     }
 };
+
+using Solver = std::function<std::optional<SolutionInfo>(const BoardImage& image)>;

--- a/src/test_suite.cpp
+++ b/src/test_suite.cpp
@@ -1,6 +1,5 @@
 #include "test_suite.h"
 #include "raw_test_data.h"
-#include "solvers/brute_force.h"
 
 #include <chrono>
 #include <unordered_set>
@@ -19,7 +18,7 @@ TestPosition TestPosition::fromImage(const BoardImage& image, const SolutionInfo
     return result;
 }
 
-void run_test_suite(TestSuite suite)
+void run_test_suite(TestSuite suite, Solver solver)
 {
     const std::vector<TestPosition>& positions = [&]()
     {
@@ -45,7 +44,7 @@ void run_test_suite(TestSuite suite)
             builder.addClearedCell(location, adjacentMines);
 
         BoardImage image = builder.build();
-        SolutionInfo solution = solvers::brute_force::solve(image).value();
+        SolutionInfo solution = solver(image).value();
 
         std::cout << image.renderSolution(solution) << std::endl;
 

--- a/src/test_suite.h
+++ b/src/test_suite.h
@@ -19,4 +19,4 @@ enum class TestSuite
     HARD
 };
 
-void run_test_suite(TestSuite suite);
+void run_test_suite(TestSuite suite, Solver solver);


### PR DESCRIPTION
This solver works the same as the brute force solver, but with 3 techniques to speed up computation
1. If the number of uncleared cells surrounding a cell is equal to the number of adjacent mines, then every uncleared cell surrounding that cell must be a mine
    - Handles cases like this
```
O..
.1.
...
```
2. If applying 1 to other cells results in all mines for this cell being solved, then the rest of the surrounding uncleared cells must not have mines
    - Handles cases like this, where the bottom 1 determines that the bottom cell is a mine, so the top mine must not be a mine.
```
O..
O1.
.1.
...
```
3. If any constraints are not satisfied during the loop, instead of just incrementing by one, it will effectively continue incrementing by one until the constraint with the largest minimum index will have it's minimum index changed (in practice, it does this with some simple math). This massively speeds up the computation as huge swaths of invalid states are pruned, whereas originally it would continue to search every invalid state one by one.
    - Essentially, if one constraint is not satisfied, it will not pointlessly try to test changes to mines in unrelated sections of the board while leaving that constraint unsatisfied.